### PR TITLE
upgraded recoverbreak()

### DIFF
--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -1578,7 +1578,20 @@ namespace ModularSkillScripts
 				if (circles[1] == "og") coinCount = targetAction.Skill.CoinList.Count;
 
 				valueList[setvalue_idx] = coinCount;
-			}
+			}else if (methodology == "haskey")
+{
+    string[] circles = circledSection.Split(',');
+    BattleUnitModel targetModel = GetTargetModel(circles[0]);
+	UNIT_KEYWORD keyword = (UNIT_KEYWORD)Enum.Parse(typeof(UNIT_KEYWORD), circles[1]);
+
+    if (targetModel == null) return;
+
+    int finalValue = 0;
+
+    if (targetModel.AssociationList.Contains(keyword) || targetModel.UnitKeywordList.Contains(keyword)) { finalValue = 1; }
+
+    valueList[setvalue_idx] = finalValue;
+}
 			else if (methodology == "allcoinstate")
 			{
 				string[] circles = circledSection.Split(',');

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -857,7 +857,19 @@ namespace ModularSkillScripts
 					{
 						targetModel.AddShield(amount, !permashield, ABILITY_SOURCE_TYPE.SKILL, battleTiming);
 					}
-				}
+				}else if (batchArgs[i].StartsWith("reuseskill"))
+{
+    string[] sectionArgs = batchArgs[i].Split(parenthesisSeparator);
+    string circledSection = sectionArgs[1];
+
+    List<BattleUnitModel> modelList = GetTargetModelList(circledSection);
+    if (modelList.Count < 1) continue;
+
+    foreach (BattleUnitModel targetModel in modelList)
+    {
+					targetModel.ReuseAction(modsa_selfAction);
+    }
+}
     			else if (batchArgs[i].StartsWith("addbreak"))
 				{
 					string[] sectionArgs = batchArgs[i].Split(parenthesisSeparator);

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -875,18 +875,21 @@ namespace ModularSkillScripts
 					}
 				}
 				else if (batchArgs[i].StartsWith("recoverbreak"))
+{
+				string[] sectionArgs = batchArgs[i].Split(parenthesisSeparator);
+				string circledSection = sectionArgs[1];
+    string[] circles = circledSection.Split(',');
+    List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
+				if (modelList.Count < 1) continue;
+
+
+    bool force = circles.Length > 1;
+    foreach (BattleUnitModel targetModel in modelList)
 				{
-					string[] sectionArgs = batchArgs[i].Split(parenthesisSeparator);
-					string circledSection = sectionArgs[1];
-
-					List<BattleUnitModel> modelList = GetTargetModelList(circledSection);
-					if (modelList.Count < 1) continue;
-
-					foreach (BattleUnitModel targetModel in modelList)
-					{
-						targetModel.RecoverAllBreak(battleTiming);
-					}
+					if (!force) { targetModel.RecoverBreak(battleTiming); }
+					if (force) { targetModel.RecoverAllBreak(battleTiming); }
 				}
+}
 				else if (batchArgs[i].StartsWith("break"))
 				{
 					string[] sectionArgs = batchArgs[i].Split(parenthesisSeparator);


### PR DESCRIPTION
previously used to recover all staggers, but now it only recovers normal staggers and if you add an opt variable it recovers all staggers like it used to so now you can recover normal staggers




new doc:

recoverbreak(var_1,opt_2)
recovers from stagger
var_1: see Multi-Target
opt_2: adding in this optional variable makes it able to recover from forced stagger

Update: added reuseskill

reuseskill(var_1)
reuses a skill
var_1: target 
(note: some targets do odd and unique things especially in loop, for example EveryEnemy will make it reuse the skill once on every enemy)
(use Self or Target for regular skill reuses,skill reuses typically target a different person by random)

Update 2: added haskey

haskey(var_1,var_2)
acqusition function, returns 0 if target doesnt have the keyword, returns 1 if it does
var_1: see single target
var_2: a keyword from unitKeywordList or associationList such as "CLAN" "SMALL" "BLADE_LINEAGE" "MIDDLE_FINGER" etc

### also can i get the edit code of the rentry documentation so i can be adding these in the docs