### PR TITLE
appearance function

### DIFF
--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -1431,8 +1431,16 @@ namespace ModularSkillScripts
 						unlockInfo_inst.UnlockPassiveStatus(targetModel.GetOriginUnitID(), pasID);
 					}
 				}
-                		case "appearance": SingletonBehavior<BattleObjectManager>.Instance.GetView(modsa_unitModel).ChangeAppearance(circledSection, true); break;
 					break;
+     				 case "appearance":
+				{
+		        		List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
+					foreach (BattleUnitModel targetModel in modelList)
+					{
+						SingletonBehavior<BattleObjectManager>.Instance.GetView(targetModel).ChangeAppearance(circles[1], true);
+					}
+				}
+				break;
 			}
 		}
 		

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -1410,8 +1410,8 @@ namespace ModularSkillScripts
 				case "endstage": Singleton<StageController>.Instance.EndStage(); break;
 				case "endbattle": Singleton<StageController>.Instance.EndBattlePhaseForcely(true); break; 
 				case "skillteamkill": break;
-                case "skillcanduel": modsa_skillModel.OverrideCanDuel(circledSection == "True"); break;
-                case "skillchangetarget": break;
+                		case "skillcanduel": modsa_skillModel.OverrideCanDuel(circledSection == "True"); break;
+                		case "skillchangetarget": break;
 				case "skilltargetnum": break;
 				case "skillcancel": break;
 				case "skillslotgive":{
@@ -1431,6 +1431,7 @@ namespace ModularSkillScripts
 						unlockInfo_inst.UnlockPassiveStatus(targetModel.GetOriginUnitID(), pasID);
 					}
 				}
+                		case "appearance": SingletonBehavior<BattleObjectManager>.Instance.GetView(modsa_unitModel).ChangeAppearance(circledSection, true); break;
 					break;
 			}
 		}

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -1432,7 +1432,7 @@ namespace ModularSkillScripts
 					}
 				}
 					break;
-     				 case "appearance":
+     				case "appearance":
 				{
 		        		List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
 					foreach (BattleUnitModel targetModel in modelList)
@@ -1440,7 +1440,19 @@ namespace ModularSkillScripts
 						SingletonBehavior<BattleObjectManager>.Instance.GetView(targetModel).ChangeAppearance(circles[1], true);
 					}
 				}
-				break;
+					break;
+    				case "coincancel":
+				{
+					foreach (string circle in circles)
+					{
+						int idx = GetNumFromParamString(circle);
+						if (idx < 0) { modsa_skillModel.DisableCoin(modsa_coinModel.GetOriginCoinIndex()); continue; }
+
+						idx = Math.Min(idx, modsa_skillModel.CoinList.Count - 1);
+						modsa_skillModel.DisableCoin(idx);
+        				}
+				}
+					break;
 			}
 		}
 		


### PR DESCRIPTION
wohoo addeed appearance function
(Note: i originally made it that  appearance just has the appearance id var and it only works on self then now i just editted it so it has a target argument)

appearance(var_1,var_2)
var_1: multi target
var_2: the appearance id to change to


another commit
coincancel(var_1~x)
works just like reusecoin where you can add multiple ids and -1 to target itself (doesnt work well) and it cancels the coin (doesnt affect clashes, which is similar when a coin is cancelled due to lack of ammo, it still clashes normally)
