### PR TITLE
update

### DIFF
--- a/ModularSkillScripts/MainClass.cs
+++ b/ModularSkillScripts/MainClass.cs
@@ -60,6 +60,7 @@ namespace ModularSkillScripts
 			timingDict.Add("OnDiscard", 24);
 			timingDict.Add("OnZeroHP", 25);
 			timingDict.Add("EnemyEndSkill", 26);
+		        timingDict.Add("OnOtherBurst", 27);
 			timingDict.Add("SpecialAction", 999);
 		}
 

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -1031,31 +1031,39 @@ namespace ModularSkillScripts
 					}
 				}
 					break;
-				case "explosion":{
-					List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
-					int times = GetNumFromParamString(circles[1]);
-
-					foreach (BattleUnitModel targetModel in modelList)
-					{
-						int tremorStack = targetModel._buffDetail.GetActivatedBuffStack(BUFF_UNIQUE_KEYWORD.Vibration, false);
-						for (int times_i = 0; times_i < times; times_i++)
-						{
-							if (abilityMode == 2)
-							{
-								dummyPassiveAbility.AddTriggeredData_BsGaugeUp(tremorStack, targetModel.InstanceID, battleTiming, true);
-								dummyPassiveAbility.FirstBsGaugeUp(modsa_unitModel, targetModel, tremorStack, battleTiming, true);
-								//targetModel.VibrationExplosion(battleTiming, modsa_unitModel, dummyPassiveAbility);
-							}
-							else
-							{
-								//dummySkillAbility.AddTriggeredData_BsGaugeUp(tremorStack, targetModel.InstanceID, battleTiming, true);
-								dummySkillAbility.FirstBsGaugeUp(modsa_unitModel, targetModel, tremorStack, battleTiming, true, modsa_selfAction);
-								//targetModel.VibrationExplosion(battleTiming, modsa_unitModel, dummySkillAbility);
-							}
-						}
-					}
-				}
-					break;
+				 case "explosion":
+				     {
+				         List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
+				         int times = GetNumFromParamString(circles[1]);
+				
+				         foreach (BattleUnitModel targetModel in modelList)
+				         {
+				             int tremorStack = targetModel._buffDetail.GetActivatedBuffStack(BUFF_UNIQUE_KEYWORD.Vibration, false);
+				             for (int times_i = 0; times_i < times; times_i++)
+				             {
+				                 if (abilityMode == 2)
+				                 {
+				                     dummyPassiveAbility.AddTriggeredData_BsGaugeUp(tremorStack, targetModel.InstanceID, battleTiming, true);
+				                     dummyPassiveAbility.FirstBsGaugeUp(modsa_unitModel, targetModel, tremorStack, battleTiming, true);
+				                     targetModel.VibrationExplosion(battleTiming, modsa_unitModel, dummyPassiveAbility);
+				                 }
+				                 else if (abilityMode == 1)
+				                 {
+				                     dummyCoinAbility.AddTriggeredData_BsGaugeUp(tremorStack, targetModel.InstanceID, battleTiming, true);
+				                     dummyCoinAbility.FirstBsGaugeUp(modsa_unitModel, targetModel, tremorStack, battleTiming, true, modsa_selfAction, modsa_coinModel);
+				                     targetModel.VibrationExplosion(battleTiming, modsa_unitModel, dummyCoinAbility, modsa_selfAction, modsa_coinModel);
+				                 }
+				                 else
+				                 {
+				                     dummySkillAbility.AddTriggeredData_BsGaugeUp(tremorStack, targetModel.InstanceID, battleTiming, true);
+				                     dummySkillAbility.FirstBsGaugeUp(modsa_unitModel, targetModel, tremorStack, battleTiming, true, modsa_selfAction);
+				                     targetModel.VibrationExplosion(battleTiming, modsa_unitModel, dummySkillAbility, modsa_selfAction);
+				                 }
+				             }
+				         }
+				     }
+				
+				     break;
 				case "healhp":{
 					List<BattleUnitModel> modelList = GetTargetModelList(circles[0]);
 					if (modelList.Count < 1) return;


### PR DESCRIPTION
fixed explosion
before: a fake tremor burst, it just raised the first stagger bar by the amount of tremor potency on the target, which is what a tremor burst does but never triggers an ACTUAL burst
after: now triggers a real burst, which also means it can activate the effects of unique tremor types and the popup actually appears and it can trigger burst-related things 

note: this doesnt work on coin timings like OSA (was always like that), otherwise its just the same as it was before where you put in a target and the amount of times to trigger it and it works

experimental feature added: OnOtherBurst, activates when someone gets tremor bursted, "Self" is overwritten by the person who got burst'd, for some reason i cant make it target like usual